### PR TITLE
asia-south1 and asia-south2 fix

### DIFF
--- a/data/regions.json
+++ b/data/regions.json
@@ -30,13 +30,13 @@
       "longitude": 126.9780
    },
    "asia-south1":{
-      "name":"Delhi, India",
+      "name":"Mumbai, India",
       "flag": "https://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
       "latitude": 19.0760,
       "longitude": 72.8777
    },
    "asia-south2":{
-      "name":"Mumbai, India",
+      "name":"Delhi, India",
       "flag": "https://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
       "latitude": 28.7041,
       "longitude": 77.1025


### PR DESCRIPTION
Region `asia-south1` is Mumbai and `asia-south2` is Delhi. Lat & Lng are OK. Source: https://cloud.google.com/compute/docs/regions-zones/